### PR TITLE
fix(gitlog): increase maxBuffer

### DIFF
--- a/src/lib/commits.js
+++ b/src/lib/commits.js
@@ -49,6 +49,9 @@ module.exports = function (config, cb) {
   function extract () {
     exec(
       'git log -E --format=%H==SPLIT==%B==END== ' + range,
+      {
+        maxBuffer: 1024 * 1024 // 1MB instead of 220KB (issue #286)
+      },
       function (err, stdout) {
         if (err) return cb(err)
 


### PR DESCRIPTION
This fixes issue #286. This is needed for repositories with a lot of commits and/or a big changelog.
